### PR TITLE
[Resolves #12] awsauth tries to create already existing users

### DIFF
--- a/awsorgs/auth.py
+++ b/awsorgs/auth.py
@@ -800,8 +800,8 @@ def main():
         sys.exit(1)
     iam_client = boto3.client('iam', **auth_credentials)
     deployed = dict(
-            users = iam_client.list_users()['Users'],
-            groups = iam_client.list_groups()['Groups'],
+            users = get_iam_objects(iam_client.list_users, 'Users'),
+            groups = get_iam_objects(iam_client.list_groups, 'Groups'),
             accounts = [a for a in scan_deployed_accounts(log, org_client)
                     if a['Status'] == 'ACTIVE'])
 

--- a/awsorgs/reports.py
+++ b/awsorgs/reports.py
@@ -24,20 +24,6 @@ def overbar(string):
     return "%s\n%s" % ('_' * len(string), string)
 
 
-def get_iam_objects(iam_client_function, object_key, f_args=dict()):
-    """
-    users = get_iam_objects(iam_client.list_users, 'Users')
-    """
-    iam_objects = []
-    response = iam_client_function(**f_args)
-    iam_objects += response[object_key]
-    if 'IsTruncated' in response:
-        while response['IsTruncated']:
-            response = iam_client_function(Marker=response['Marker'],**f_args)
-            iam_objects += response[object_key]
-    return iam_objects
-
-
 def report_maker(log, accounts, role, query_func, report_header=None, **qf_args):
     """
     Generate a report by running a arbitrary query function in each account.


### PR DESCRIPTION
auth.py: use util function get_iam_objects() when building deployed['users'].
This checks for truncated responses from iam_client.list_users()

remove redundant declaration of get_iam_objects() from reports.py